### PR TITLE
check_chain_validity "block has no attribute hash" error fix

### DIFF
--- a/node_server.py
+++ b/node_server.py
@@ -102,7 +102,7 @@ class Blockchain:
             # using `compute_hash` method.
             delattr(block, "hash")
 
-            if not cls.is_valid_proof(block, block.hash) or \
+            if not cls.is_valid_proof(block, block_hash) or \
                     previous_hash != block.previous_hash:
                 result = False
                 break


### PR DESCRIPTION
block.hash was called after it has been deleted from the Block object it is good to use the block_hash variable instead. Thank You