### PR TITLE
Use a version of markupsafe prior to 2.1.0.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask~=1.1
 requests~=2.22
+markupsafe<2.1.0


### PR DESCRIPTION
Fixes: "ImportError: cannot import name 'soft_unicode' from 'markupsafe'"